### PR TITLE
ci: fix codecov coverage upload

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -17,12 +17,14 @@ jobs:
       - name: test
         run: |
           dart analyze
-          dart test --coverage=~/coverage
+          dart test --coverage=coverage
+      - name: convert coverage to lcov
+        run: dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
       - name: uploard codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          file: ~/coverage/lcov.info
+          files: coverage/lcov.info
   slack-notify:
     if: always()
     needs: [test]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,5 +7,6 @@ environment:
   sdk: '>=3.1.1 <4.0.0'
 
 dev_dependencies:
+  coverage: any # Provides format_coverage to convert JSON coverage to lcov format
   lints: any # Ignoring the version to allow editing across SDK versions.
   test: any # Ignoring the version to allow editing across SDK versions.


### PR DESCRIPTION
## Summary

The codecov upload step in CI was failing for two reasons:

1. **No coverage report was generated.** `dart test --coverage` emits coverage in JSON format, and there was no step converting it to the lcov format codecov expects, so `lcov.info` never existed (`Found 0 coverage files to report`).
2. **The codecov-action input name was wrong.** The action renamed `file` (singular) to `files` (plural); the old `file:` input was silently ignored, leaving the upload target unspecified (`Warning: Unexpected input(s) 'file'`).

## Changes

- Add the `coverage` package to `dev_dependencies` (provides `format_coverage`).
- Add a `convert coverage to lcov` step running `format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib`.
- Rename the codecov-action input `file:` to `files:`.
- Switch the coverage output dir from the tilde-ambiguous `~/coverage` to the repo-relative `coverage/`.

## Verification

Reproduced the CI flow locally:

- `dart test --coverage=coverage` -> all 11 tests pass, JSON coverage generated under `coverage/`.
- `dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib` -> exit 0, `coverage/lcov.info` generated with `SF:` records for both `lib/src/` files.